### PR TITLE
hotfix/TOPS-800: Renaming gsoft-inc organization to workleap in github.

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -16,11 +16,11 @@ To get an overview of the project, read the [README](../README.md).
 
 #### Create a new issue
 
-If you spot a problem with the components, [search if an issue already exists](https://docs.github.com/en/github/searching-for-information-on-github/searching-on-github/searching-issues-and-pull-requests#search-by-the-title-body-or-comments) on our [issues page](https://github.com/gsoft-inc/ov-igloo-icons/issues). If a related issue doesn't exist, you can [open a new issue](https://github.com/gsoft-inc/ov-igloo-icons/issues/new).
+If you spot a problem with the components, [search if an issue already exists](https://docs.github.com/en/github/searching-for-information-on-github/searching-on-github/searching-issues-and-pull-requests#search-by-the-title-body-or-comments) on our [issues page](https://github.com/workleap/ov-igloo-icons/issues). If a related issue doesn't exist, you can [open a new issue](https://github.com/workleap/ov-igloo-icons/issues/new).
 
 #### Solve an issue
 
-Scan through our [existing issues](https://github.com/gsoft-inc/ov-igloo-icons/issues) to find one that interests you. As a general rule, we don’t assign issues to anyone. If you find an issue to work on, you are welcome to open a PR with a fix.
+Scan through our [existing issues](https://github.com/workleap/ov-igloo-icons/issues) to find one that interests you. As a general rule, we don’t assign issues to anyone. If you find an issue to work on, you are welcome to open a PR with a fix.
 
 ### Make Changes
 

--- a/README.md
+++ b/README.md
@@ -102,4 +102,4 @@ For projects that don’t use React, icons are also available as \*.svg files in
 
 ## License
 
-Copyright © 2019, GSoft inc. This code is licensed under the Apache License, Version 2.0. You may obtain a copy of this license at https://github.com/gsoft-inc/gsoft-license/blob/master/LICENSE.
+Copyright © 2019, GSoft inc. This code is licensed under the Apache License, Version 2.0. You may obtain a copy of this license at https://github.com/workleap/gsoft-license/blob/master/LICENSE.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/gsoft-inc/ov-igloo-icons.git"
+    "url": "git+https://github.com/workleap/ov-igloo-icons.git"
   },
   "keywords": [
     "igloo-ui",
@@ -29,9 +29,9 @@
   "author": "Groupe Officevibe Inc.",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/gsoft-inc/ov-igloo-icons/issues"
+    "url": "https://github.com/workleap/ov-igloo-icons/issues"
   },
-  "homepage": "https://github.com/gsoft-inc/ov-igloo-icons#readme",
+  "homepage": "https://github.com/workleap/ov-igloo-icons#readme",
   "dependencies": {
     "classnames": "^2.3.1",
     "html-react-parser": "^1.2.7"


### PR DESCRIPTION
TOPS-800: Replacing gsoft-inc/wl-reusable-workflows by workleap/wl-reusable-workflows

--
Not sure why this PR has been created? Reach TechOps in our public slack channel: #techops-and-friends
Some context on the why of this PR can be found here: https://workleap.slack.com/archives/C02E9KPRQ7P/p1737385211295479 